### PR TITLE
Exclude node_modules to upload artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,9 @@ jobs:
         if: github.event_name == 'release'
         with:
           name: lib
-          path: ./
+          path: |
+            ./
+            !./node_modules/**/*
 
   deploy:
     # We only need to deploy if we're on the main branch


### PR DESCRIPTION
node_modules をアーティファクトのアップロード時に除外し、CI 実行時間を短縮します。