### PR TITLE
Fix excluding npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/opendata-editor",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://geolonia.github.io/opendata-editor/",
   "type": "module",
   "files": [

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -2,6 +2,9 @@ import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
+import { dependencies, devDependencies } from './package.json';
+
+const deps = Object.keys(dependencies).concat(Object.keys(devDependencies));
 
 export default defineConfig({
   build: {
@@ -13,7 +16,7 @@ export default defineConfig({
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
-      external: [/node_modules/],
+      external: deps,
     },
   },
   plugins: [


### PR DESCRIPTION
バンドルされた JS で npm パッケージを `import` する箇所で、パッケージ名ではなく絶対パスでファイルが指定されており、ビルドした環境以外では正しく動作していません。

```js
import { jsxs as E, jsx as a, Fragment as I } from "/home/geolonia/dev/opendata-editor/node_modules/react/jsx-runtime.js";
```

この PR により、バンドルされた JS ファイルでの `import` は、下記のようにパッケージ名からインストールする形に修正されます。

```js
import _, { useCallback as J } from "react";
```