### PR TITLE
fix: remove unwanted margins from `<Uploader>`

### DIFF
--- a/lib/OpenDataEditor.tsx
+++ b/lib/OpenDataEditor.tsx
@@ -26,18 +26,18 @@ const baseStyle = `
 `;
 const OuterWrapper = styled.div`
   ${baseStyle}
-  padding: 16px;
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: 12px 0 8px -8px rgba(243, 152, 19, 0.1) inset;
   z-index: 9999;
 `;
 const InnerWrapper = styled.div`
   box-sizing: border-box;
   color: #2b2b2b;
-  width: 98%;
-  margin: 0 auto;
+  width: 100%;
+  padding-left: 2.25rem;
+  padding-right: 2.25rem;
+  padding-top: 1rem;
 `;
 const StyledUploader = styled(Uploader)`
   ${baseStyle}
@@ -107,8 +107,8 @@ const OpenDataEditor = ({ data, onDataUpdate }: Props): JSX.Element => {
 
   return (
     <OuterWrapper>
+      <StyledUploader className="uploader" setFeatures={setFeatures} filename={filename} setFilename={setFilename} setFitBounds={setFitBounds} />
       <InnerWrapper>
-        <StyledUploader className="uploader" setFeatures={setFeatures} filename={filename} setFilename={setFilename} setFitBounds={setFitBounds}></StyledUploader>
         <Download features={features} filename={filename} />
 
         <StyledMap


### PR DESCRIPTION
Closes #31

アップローダーの余白を削除しました。
アップロードを行い、テーブルが表示された後の余白は維持しています。

![](https://github.com/geolonia/opendata-editor/assets/315601/cf089f9c-b111-4c2b-be15-b9ca3e81663a)
![](https://github.com/geolonia/opendata-editor/assets/315601/00c46e0b-8e2c-445d-ab87-2da6c8678e70)
