### PR TITLE
Excel をダウンロード時に時刻が小数に変換される問題を修正

### DIFF
--- a/lib/Download.tsx
+++ b/lib/Download.tsx
@@ -31,7 +31,7 @@ const Component = (props: Props) => {
       const newFeature: Feature = {};
       for (let i = 0; i < Object.keys(feature).length; i++) {
         if (Object.keys(feature)[i] !== 'id' && Object.keys(feature)[i] !== 'title') {
-          newFeature[Object.keys(feature)[i]] = `${Object.values(feature)[i]}`;
+          newFeature[Object.keys(feature)[i]] = Object.values(feature)[i];
         }
       }
       return newFeature;

--- a/lib/Download.tsx
+++ b/lib/Download.tsx
@@ -1,7 +1,7 @@
 import React, { type MouseEvent } from 'react';
 import Papa from 'papaparse';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
-import { write, read } from 'xlsx';
+import { write, utils } from 'xlsx';
 import { styled } from 'styled-components';
 import Button from './Button';
 
@@ -31,7 +31,7 @@ const Component = (props: Props) => {
       const newFeature: Feature = {};
       for (let i = 0; i < Object.keys(feature).length; i++) {
         if (Object.keys(feature)[i] !== 'id' && Object.keys(feature)[i] !== 'title') {
-          newFeature[Object.keys(feature)[i]] = Object.values(feature)[i];
+          newFeature[Object.keys(feature)[i]] = `${Object.values(feature)[i]}`;
         }
       }
       return newFeature;
@@ -49,7 +49,8 @@ const Component = (props: Props) => {
     document.body.removeChild(csvAtag);
 
     // Excel ダウンロード
-    const workbook = read(output, {type: 'binary'});
+    const ws = utils.json_to_sheet(exportData);
+    const workbook = { Sheets: { 'Sheet1': ws }, SheetNames: ['Sheet1'] };
     const wbout = write(workbook, {bookType: 'xlsx', type: 'array'});
 
     const excelAtag = document.createElement('a');


### PR DESCRIPTION
以下のように、配列データを workbookオブジェクトを生成すると、08:30 を数値に変換してしまっていた。

```
const workbook = read(output, {type: 'binary'});
```

以下のように、`json_to_sheet` を使うことで、配列の値をそのまま Excel に変換することで、`08:30` を文字列として保存するように修正しました。

```
const ws = utils.json_to_sheet(exportData);
const workbook = { Sheets: { 'Sheet1': ws }, SheetNames: ['Sheet1'] };
```
データ型
![スクリーンショット 2023-08-29 17 40 47](https://github.com/geolonia/opendata-editor/assets/8760841/a7afafc3-1c52-4e55-b6ca-f4cb0df134c8)
