### PR TITLE
Deploy under root dir on preview env (Cloudflare Pages)

### DIFF
--- a/vite.config.web.ts
+++ b/vite.config.web.ts
@@ -11,5 +11,5 @@ export default defineConfig({
   },
   plugins: [react()],
   publicDir: resolve(__dirname, 'web/public'),
-  base: '/opendata-editor/',
+  base: process.env.NODE_ENV === 'preview' ? '/' : '/opendata-editor/',
 });


### PR DESCRIPTION
Cloudflare Pages のプレビュー環境では、ドメインルート直下 (https://*.opendata-editor-preview.pages.dev/opendata-editor/) にデプロイされるため、`NODE_ENV` でベースディレクトリーの分岐を行いました。