### PR TITLE
Deploy on release, not on merge to `main`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,11 +46,9 @@ jobs:
             !./node_modules/**/*
 
   deploy:
-    # We only need to deploy if we're on the main branch
-    if: github.ref == 'refs/heads/main'
-
     needs:
       - build
+    if: github.event_name == 'release'
 
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:


### PR DESCRIPTION
これまで Web アプリケーション版は main にマージされた時にデプロイされるようになっており、ライブラリー版は Release が作成された時に publish されるようになっていましたが、どちらも Release が作成された時にデプロイ・publish されるように揃えました。

尚、main にマージされた際には、プレビュー環境として Cloudflare Pages ( https://opendata-editor-preview.pages.dev ) にデプロイされるようになっています。
