### PR TITLE
Detect rows with invalid latitude or longitude

### DIFF
--- a/lib/EventLink.tsx
+++ b/lib/EventLink.tsx
@@ -1,0 +1,31 @@
+import type { MouseEventHandler, ReactNode } from 'react';
+import { styled } from 'styled-components';
+
+const StyledEventLink = styled.span`
+  cursor: pointer;
+
+  color: #0000EE;
+  &:hover{
+    color: #0000EE;
+    text-decoration: underline;
+  }
+  &:active {
+    color: #551A8B;
+  }
+`;
+
+type Props = {
+  className?: string; // Required to apply styles by styled-components
+  children: ReactNode;
+  onClick: MouseEventHandler<HTMLSpanElement>;
+};
+
+const EventLink = ({ className, children, onClick = () => {} }: Props) => {
+  return (
+    <StyledEventLink className={className} onClick={onClick}>
+      {children}
+    </StyledEventLink>
+  );
+};
+
+export default EventLink;

--- a/lib/OpenDataEditor.tsx
+++ b/lib/OpenDataEditor.tsx
@@ -27,6 +27,8 @@ import 'react-data-grid/lib/styles.css';
 import 'react-contexify/ReactContexify.css';
 import './datagrid.css';
 import { getLatLngColumnNames, getRowById, getInvalidFeatureIndexes } from './utils/utils';
+import Popup from './Popup';
+import EventLink from './EventLink';
 
 const baseStyle = `
   position: absolute;
@@ -63,6 +65,10 @@ const StyledMap = styled(Map)`
   height: 400px;
   box-sizing: border-box;
   margin-bottom: 20px;
+`;
+const Text = styled.p`
+  margin: 0;
+  padding: 0;
 `;
 
 const getColumns = (data: Feature[]): Column<Feature>[] => {
@@ -166,6 +172,12 @@ const OpenDataEditor = ({ data, onDataUpdate }: Props): JSX.Element => {
 
     setInvalidFeatureIndexes(getInvalidFeatureIndexes(features));
   }, [features]);
+
+  useEffect(() => {
+    if (invalidFeatureIndexes.length > 0) {
+      gridRef.current?.scrollToCell({ rowIdx: invalidFeatureIndexes[0] });
+    }
+  }, [invalidFeatureIndexes]);
 
   const onMapPinMoved = useCallback((rowId: string, newLatitude: number, newLongitude: number) => {
     const { latColumnName, lngColumnName } = getLatLngColumnNames(features);
@@ -304,6 +316,17 @@ const OpenDataEditor = ({ data, onDataUpdate }: Props): JSX.Element => {
         <Separator />
         <Item id="delete" onClick={onContextMenuItemClick} data-e2e="delete">この行を削除</Item>
       </Menu>
+
+      <Popup enabled={invalidFeatureIndexes.length > 0} title="データにエラーがあります">
+        <Text>緯度経度の値が不正なデータがあります。緯度は -90〜90、経度は -180〜180 の間の値を指定して下さい。</Text>
+        <ul>
+          {(invalidFeatureIndexes.slice(0, 6)).map((invalidFeatureIndex) => (
+            <li key={invalidFeatureIndex}>
+              <EventLink onClick={() => gridRef.current?.scrollToCell({ rowIdx: invalidFeatureIndex })}>{invalidFeatureIndex}行目</EventLink>
+            </li>
+          ))}
+        </ul>
+      </Popup>
     </OuterWrapper>
   );
 };

--- a/lib/OpenDataEditor.tsx
+++ b/lib/OpenDataEditor.tsx
@@ -25,7 +25,8 @@ import { csv2rows } from './utils/csv2geojson';
 import type { Cell, Feature } from './types';
 import 'react-data-grid/lib/styles.css';
 import 'react-contexify/ReactContexify.css';
-import { getLatLngColumnNames, getRowById } from './utils/utils';
+import './datagrid.css';
+import { getLatLngColumnNames, getRowById, getInvalidFeatureIndexes } from './utils/utils';
 
 const baseStyle = `
   position: absolute;
@@ -93,6 +94,7 @@ const OpenDataEditor = ({ data, onDataUpdate }: Props): JSX.Element => {
   });
 
   const [ features, setFeatures ] = useState<Feature[]>([]);
+  const [ invalidFeatureIndexes, setInvalidFeatureIndexes ] = useState<number[]>([]);
   const [ columns, setColumns ] = useState<Column<Feature>[]>([]);
   const [ filename, setFilename ] = useState<string>('');
   const [ , setFitBounds ] = useState(false);
@@ -161,6 +163,8 @@ const OpenDataEditor = ({ data, onDataUpdate }: Props): JSX.Element => {
       gridRef.current?.selectCell({ idx: columnIdx, rowIdx: features.length - 1 });
       selectNewRowOnNextRowUpdate.current = false;
     }
+
+    setInvalidFeatureIndexes(getInvalidFeatureIndexes(features));
   }, [features]);
 
   const onMapPinMoved = useCallback((rowId: string, newLatitude: number, newLongitude: number) => {
@@ -285,6 +289,9 @@ const OpenDataEditor = ({ data, onDataUpdate }: Props): JSX.Element => {
             resizable: true,
           }}
           rowKeyGetter={(row: Feature) => row.id}
+          rowClass={(_, index) =>
+            invalidFeatureIndexes.includes(index) ? 'error-row' : undefined
+          }
           onRowsChange={setFeatures}
           onSelectedCellChange={onSelectedCellChange}
           onCellContextMenu={onCellContextMenu}

--- a/lib/Popup.tsx
+++ b/lib/Popup.tsx
@@ -1,0 +1,77 @@
+import { useState, type ReactNode } from 'react';
+import { faWindowMinimize, faWindowRestore } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import styled from 'styled-components';
+
+const StyledPopup = styled.div`
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+
+  background-color: #FFFFFF;
+
+  border-color: rgb(209, 36, 47);
+  border-width: 4px;
+  border-style: solid;
+  border-radius: 8px;
+
+  z-index: 9999;
+`;
+const Bar = styled.div`
+  margin: 0;
+  padding: 0.75rem;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+`;
+const Main = styled.div`
+  padding: 0.75rem;
+`;
+const Title = styled.p`
+  margin: 0;
+  padding: 0;
+
+  font-weight: 600;
+`;
+const Icon = styled(FontAwesomeIcon)`
+  padding: 4px;
+
+  border-color: #000000;
+  border-width: 1px;
+  border-style: solid;
+
+  cursor: pointer;
+`;
+
+type Props = {
+  children: ReactNode;
+  enabled: boolean;
+  title: string;
+};
+
+const Popup = ({ children, enabled = false, title }: Props) => {
+  const [ minimized, setMinimized ] = useState<boolean>(false);
+
+  return (
+    <>
+      <StyledPopup style={{ display: enabled ? 'block' : 'none' }}>
+        <Bar>
+          <Title>{title}</Title>
+          <Icon
+            icon={minimized ? faWindowRestore : faWindowMinimize}
+            onClick={() => setMinimized((minimized) => !minimized)}
+          />
+        </Bar>
+        { !minimized && (
+          <Main>
+            {children}
+          </Main>
+        )}
+      </StyledPopup>
+    </>
+  );
+};
+
+export default Popup;

--- a/lib/datagrid.css
+++ b/lib/datagrid.css
@@ -1,0 +1,4 @@
+.error-row > .rdg-cell {
+  background-color: rgb(209, 36, 47);
+  color: white;
+}

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -25,3 +25,28 @@ export const getLatLngColumnNames = (row: Feature | Feature[]): { latColumnName?
     lngIndex,
   };
 };
+
+export const getInvalidFeatureIndexes = (features: Feature[]): number[] => {
+  if (features.length === 0) {
+    return [];
+  }
+
+  const { latColumnName, lngColumnName } = getLatLngColumnNames(features[0]);
+
+  if (!latColumnName || !lngColumnName) {
+    return [];
+  }
+
+  const invalidIndexes: number[] = [];
+
+  for (const [i, feature] of features.entries()) {
+    const lng = Number(feature[lngColumnName]);
+    const lat = Number(feature[latColumnName]);
+
+    if (!(lng >= -180 && lng <= 180 && lat >= -90 && lat <= 90)) {
+      invalidIndexes.push(i);
+    }
+  }
+
+  return invalidIndexes;
+};


### PR DESCRIPTION
不正な緯度経度がデータに含まれる場合に、エラーメッセージを表示し、エラー行 (複数貼る場合は一番上のエラー行) までスクロールするように修正しました。

プレビュー環境: https://feat-invlaid-latlng.opendata-editor-preview.pages.dev/?data=https://opendata.takamatsu-fact.com/aed_location/data.csv

![](https://github.com/geolonia/opendata-editor/assets/315601/360d14b3-c358-4891-96f8-d7691f820fc3)
