### PR TITLE
Do not run `playwright install` when playwright is not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:web": "vite build --config ./vite.config.web.ts",
     "test": "vitest run && playwright test",
     "lint": "tsc --noEmit && eslint . --ext js,jsx,ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "postinstall": "npm list @playwright/test && playwright install"
+    "postinstall": "if npm list @playwright/test; then playwright install; fi"
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.2.0",


### PR DESCRIPTION
恐らく npm の仕様変更により、`@playwright/test` がインストールされている時にのみ `playwright install` を実行する処理が、`@playwright/test` がインストールされていない時に常に失敗するようになりました。
本 PR により、正常に動作するよう復旧します。